### PR TITLE
Speed up Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ sudo: required
 dist: trusty
 env:
  matrix:
-  - TTT=linux    KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
-  - TTT=next     KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git" GCOV=1
-  - TTT=net-next KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git"
-  - TTT=userns-t KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/ebiederm/user-namespace.git -b for-testing"
-  - TTT=userns-n KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/ebiederm/user-namespace.git -b for-next"
-  - TTT=akpm     KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git -b akpm"
-  - TTT=pre-akpm KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git -b akpm-base"
-  - TTT=cgroup   KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/tj/cgroup.git -b for-next"
-  - TTT=vfs      KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/viro/vfs.git -b for-next"
+  - TTT=linux    KGIT="http://kernel.googlesource.com/pub/scm/linux/kernel/git/torvalds/linux.git"
+  - TTT=next     KGIT="http://kernel.googlesource.com/pub/scm/linux/kernel/git/next/linux-next.git" GCOV=1
+  - TTT=net-next KGIT="http://kernel.googlesource.com/pub/scm/linux/kernel/git/davem/net-next.git"
+  - TTT=userns-t KGIT="http://kernel.googlesource.com/pub/scm/linux/kernel/git/ebiederm/user-namespace.git -b for-testing"
+  - TTT=userns-n KGIT="http://kernel.googlesource.com/pub/scm/linux/kernel/git/ebiederm/user-namespace.git -b for-next"
+  - TTT=akpm     KGIT="http://kernel.googlesource.com/pub/scm/linux/kernel/git/next/linux-next.git -b akpm"
+  - TTT=pre-akpm KGIT="http://kernel.googlesource.com/pub/scm/linux/kernel/git/next/linux-next.git -b akpm-base"
+  - TTT=cgroup   KGIT="http://kernel.googlesource.com/pub/scm/linux/kernel/git/tj/cgroup.git -b for-next"
+  - TTT=vfs      KGIT="http://kernel.googlesource.com/pub/scm/linux/kernel/git/viro/vfs.git -b for-next"
  global:
   - secure: "pLXteR7eodHe2qp5q1wB+W53OOd/9b5q1IHPajh5ES86Yvut5ig7pUhmLU75hDcu7TPeISYl2//Et9xxbBF0h2z1dqtTlvAnN+THBmIZ4Yv4X+LMkD532sI/AQpCJHVOXQ5r6tLgWQqL0zEC20ImC0LaJfz6qFSmdQ8uX/r61r8="
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,19 @@ sudo: required
 dist: trusty
 env:
  matrix:
-  - TTT=linux    TR_ARCH=local KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
-  - TTT=next     TR_ARCH=local KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git" GCOV=1
-  - TTT=net-next TR_ARCH=local KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git"
-  - TTT=userns-t TR_ARCH=local KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/ebiederm/user-namespace.git -b for-testing"
-  - TTT=userns-n TR_ARCH=local KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/ebiederm/user-namespace.git -b for-next"
-  - TTT=akpm     TR_ARCH=local KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git -b akpm"
-  - TTT=pre-akpm TR_ARCH=local KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git -b akpm-base"
-  - TTT=cgroup   TR_ARCH=local KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/tj/cgroup.git -b for-next"
-  - TTT=vfs      TR_ARCH=local KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/viro/vfs.git -b for-next"
+  - TTT=linux    KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+  - TTT=next     KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git" GCOV=1
+  - TTT=net-next KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git"
+  - TTT=userns-t KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/ebiederm/user-namespace.git -b for-testing"
+  - TTT=userns-n KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/ebiederm/user-namespace.git -b for-next"
+  - TTT=akpm     KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git -b akpm"
+  - TTT=pre-akpm KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git -b akpm-base"
+  - TTT=cgroup   KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/tj/cgroup.git -b for-next"
+  - TTT=vfs      KGIT="git://git.kernel.org/pub/scm/linux/kernel/git/viro/vfs.git -b for-next"
  global:
   - secure: "pLXteR7eodHe2qp5q1wB+W53OOd/9b5q1IHPajh5ES86Yvut5ig7pUhmLU75hDcu7TPeISYl2//Et9xxbBF0h2z1dqtTlvAnN+THBmIZ4Yv4X+LMkD532sI/AQpCJHVOXQ5r6tLgWQqL0zEC20ImC0LaJfz6qFSmdQ8uX/r61r8="
 script:
-  - sudo make -C scripts/travis $TR_ARCH
+  - sudo make -C scripts/travis local
 after_success:
   - make -C scripts/travis after_success
 after_failure:

--- a/scripts/travis/kexec.sh
+++ b/scripts/travis/kexec.sh
@@ -39,6 +39,9 @@ true && {
 	cd ..
 }
 
+# Disable Docker daemon start after reboot; upstart way
+echo manual > /etc/init/docker.override
+
 setsid bash -c "setsid ./scripts/travis/kexec-dump.sh $ppid < /dev/null &> /travis.log &"
 for i in `seq 10`; do
 	sleep 15

--- a/scripts/travis/kexec.sh
+++ b/scripts/travis/kexec.sh
@@ -24,7 +24,7 @@ true && {
 	modprobe macvlan
 	modprobe veth
 
-	git clone --depth 1 $KGIT linux
+	time git clone --depth 1 $KGIT linux
 #	git clone git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git linux
 	cp scripts/linux-next-config linux/.config
 	cd linux

--- a/scripts/travis/kexec.sh
+++ b/scripts/travis/kexec.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
-
 set -x
+
+if [ "$1" = 'prep' ]; then
+	time git clone --depth 1 $KGIT linux
+	modprobe tun
+	modprobe macvlan
+	modprobe veth
+
+	cp scripts/linux-next-config linux/.config
+	cd linux
+	make olddefconfig
+	exit 0
+fi
 
 uname -a
 cat /proc/cpuinfo
@@ -20,26 +31,13 @@ while :; do
 done
 
 true && {
-	modprobe tun
-	modprobe macvlan
-	modprobe veth
-
-	time git clone --depth 1 $KGIT linux
-#	git clone git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git linux
-	cp scripts/linux-next-config linux/.config
 	cd linux
-#	git checkout -f 93a205ee98a4881e8bf608e65562c19d45930a93
-#	git clean -dxf
-	make olddefconfig
 	yes "" | make localyesconfig
 	make olddefconfig
 	time make -j 4
 	make kernelrelease
 	cd ..
 }
-
-
-ls -l /boot/
 
 setsid bash -c "setsid ./scripts/travis/kexec-dump.sh $ppid < /dev/null &> /travis.log &"
 for i in `seq 10`; do

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -1,4 +1,8 @@
 #!/bin/bash
+cd ../../
+./scripts/travis/kexec.sh prep &
+PREP_PID=$!
+
 set -x -e
 
 cat /proc/cmdline
@@ -12,8 +16,6 @@ TRAVIS_PKGS="protobuf-c-compiler libprotobuf-c0-dev libaio-dev
 
 travis_prep () {
 	[ -n "$SKIP_TRAVIS_PREP" ] && return
-
-	cd ../../
 
 	service apport stop
 

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -34,6 +34,7 @@ export GCOV
 make -j4 ${MAKE_VARS}
 
 ./criu/criu check --extra --all || echo $?
+make -j4 ${MAKE_VARS} -C test/zdtm
 python test/zdtm.py run -t zdtm/static/env00
 
 date

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -53,10 +53,6 @@ date
 
 umask 0000
 export SKIP_PREP=1
-# The 3.19 Ubuntu kernel has a bug. When pagemap are read for a few vma-s
-# for one read call, it returns incorrect data.
-# https://github.com/xemul/criu/issues/207
-export CRIU_PMC_OFF=1
 
 chmod a+w -R .
 chmod 0777 test/

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -1,7 +1,8 @@
 #!/bin/bash
+
 cd ../../
-./scripts/travis/kexec.sh prep &
-PREP_PID=$!
+set -m
+./scripts/travis/kexec.sh prep > kexec-prep.log 2>&1 &
 
 set -x -e
 
@@ -40,6 +41,8 @@ make -j4 ${MAKE_VARS} -C test/zdtm
 python test/zdtm.py run -t zdtm/static/env00
 
 date
+wait # for kexec.sh prep to finish
+cat kexec-prep.log
 ./scripts/travis/kexec.sh
 date
 

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -31,7 +31,7 @@ travis_prep
 
 
 export GCOV
-make ${MAKE_VARS}
+make -j4 ${MAKE_VARS}
 
 ./criu/criu check --extra --all || echo $?
 python test/zdtm.py run -t zdtm/static/env00
@@ -42,7 +42,7 @@ date
 
 ulimit -c unlimited
 echo "|`pwd`/test/abrt.sh %P %p %s %e" > /proc/sys/kernel/core_pattern
-make ${MAKE_VARS} -C test/zdtm
+make -j4 ${MAKE_VARS} -C test/zdtm
 
 date
 ./criu/criu check


### PR DESCRIPTION
Here are a few speedups I was able to come up with.

- Do kernel preparation (mostly git clone) in parallel with the main thread
- Use Google CDN to save a few seconds :)
- Use -j4 for make where appropriate
- Some minor cleanups here and there

Now, I haven't done any exact time measurements (except for git clone), but it
looks like these changed, combined, decrease job time from 35-37 minutes
down to 33-36, i.e. there's a minute or two shaved off.